### PR TITLE
join the spin_thread_ in the derived class destructors

### DIFF
--- a/src/costmap_to_lines_convex_hull.cpp
+++ b/src/costmap_to_lines_convex_hull.cpp
@@ -56,6 +56,8 @@ CostmapToLinesDBSMCCH::~CostmapToLinesDBSMCCH()
 {
   if (dynamic_recfg_ != NULL)
     delete dynamic_recfg_;
+  // Wait until the spin_thread_ joins.
+  stopWorker();
 }
   
 void CostmapToLinesDBSMCCH::initialize(ros::NodeHandle nh)

--- a/src/costmap_to_lines_ransac.cpp
+++ b/src/costmap_to_lines_ransac.cpp
@@ -55,6 +55,8 @@ CostmapToLinesDBSRANSAC::~CostmapToLinesDBSRANSAC()
 {
   if (dynamic_recfg_ != NULL)
     delete dynamic_recfg_;
+  // Wait until the spin_thread_ joins.
+  stopWorker();
 }
   
 void CostmapToLinesDBSRANSAC::initialize(ros::NodeHandle nh)

--- a/src/costmap_to_polygons.cpp
+++ b/src/costmap_to_polygons.cpp
@@ -116,6 +116,8 @@ CostmapToPolygonsDBSMCCH::~CostmapToPolygonsDBSMCCH()
 {
   if (dynamic_recfg_ != NULL)
     delete dynamic_recfg_;
+  // Wait until the spin_thread_ joins.
+  stopWorker();
 }
 
 void CostmapToPolygonsDBSMCCH::initialize(ros::NodeHandle nh)

--- a/src/costmap_to_polygons_concave.cpp
+++ b/src/costmap_to_polygons_concave.cpp
@@ -54,6 +54,8 @@ CostmapToPolygonsDBSConcaveHull::~CostmapToPolygonsDBSConcaveHull()
 {
   if (dynamic_recfg_ != NULL)
     delete dynamic_recfg_;
+  // Wait until the spin_thread_ joins.
+  stopWorker();
 }
 
 void CostmapToPolygonsDBSConcaveHull::initialize(ros::NodeHandle nh)


### PR DESCRIPTION
Fixing possible access to pure virtual functions.

The base functions `compute` and `updateCostmap2D` are pure virtual. When the instance gets destructed we would join the spin_thread after destructing the derived classes (which would implement the two mentioned methods), leading to a call to the pure virtual base functions. 

In order to prevent this, we wait in the derived classes for the spin_thread to join.